### PR TITLE
Add UI ignore rules to .covrignore

### DIFF
--- a/.covrignore
+++ b/.covrignore
@@ -1,2 +1,4 @@
 *-ui.R
 *_ui.R
+R/*-ui.R
+R/*_ui.R


### PR DESCRIPTION
Currently the ui files are not being ignored, while they should be. This commit is an attempt to change that. This pull request fixes .covrignore so ui files are actually ignored as specified in #6