### PR TITLE
Ignore main server - correct branch

### DIFF
--- a/.covrignore
+++ b/.covrignore
@@ -2,3 +2,5 @@
 *_ui.R
 R/*-ui.R
 R/*_ui.R
+R/main_server.R
+R/run.R


### PR DESCRIPTION
This pull request resolves #7 by adding `main_server.R` and `run.R` to `.covrignore`