### PR TITLE
Fix travis-ci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # cdphmd
 
 <!-- badges: start -->
-[![Travis build status](https://travis-ci.com/ikbentimkramer/cdphmd.svg?branch=master)](https://travis-ci.com/ikbentimkramer/cdphmd)
+[![Travis build status](https://travis-ci.org/ikbentimkramer/cdphmd.svg?branch=master)](https://travis-ci.org/ikbentimkramer/cdphmd)
 [![codecov](https://codecov.io/gh/ikbentimkramer/cdphmd/branch/master/graph/badge.svg?token=I9K0S5EY54)](https://codecov.io/gh/ikbentimkramer/cdphmd)
 <!-- badges: end -->
 


### PR DESCRIPTION
The travis-ci badge was pointed to the wrong url, which resulted in the badge not updating. This pr fixes that