### PR TITLE
Fix linegraph reactive test not ignoring dplyr warning

### DIFF
--- a/tests/testthat/test-mod-line_graph.R
+++ b/tests/testthat/test-mod-line_graph.R
@@ -30,10 +30,12 @@ test_that("column name strings get converted to formulas correctly",{
 })
 
 test_that("line_graph_server accepts reactives", {
-  shiny::testServer(
-    line_graph_server,
-    args = list(x = "foo", y = "bar", df = shiny::reactive({input})),
-    {
-      expect_error(output$linegraph, NA)
-    })
+  rlang::with_options(lifecycle_verbosity = "quiet", {
+    shiny::testServer(
+      line_graph_server,
+      args = list(x = "foo", y = "bar", df = shiny::reactive({input})),
+      {
+        expect_error(output$linegraph, NA)
+      })
+  })
 })


### PR DESCRIPTION
Fixes the newly emerged dplyr warning in linegraph's reactive test. Fixes #37 